### PR TITLE
fix: add correct path for main & module entry 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
       "url": "https://bit.ly/mrdgh2821"
     }
   ],
-  "main": "./index.js",
+  "main": "./dist/index.js",
+	"module": "./dist/index.mjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/Khaenri-ah/ruinguard-core.git"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     }
   ],
   "main": "./dist/index.js",
-	"module": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/Khaenri-ah/ruinguard-core.git"


### PR DESCRIPTION
This allows the node resolver to work correctly and not throw error/warnings.

Code snippet borrowed from [here](https://github.com/discordjs/discord.js/blob/361709332bdc871822c2b9919f14fd090d68666a/packages/builders/package.json#L15)